### PR TITLE
企画ページへのリンクはリダイレクトに

### DIFF
--- a/event/index.html
+++ b/event/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>第67回理工展 企画ページ</title>
+</head>
+<body>
+    <script>
+        location.replace('/')
+    </script>
+
+    Will be published at Nov 7. Redirecting to <a href='/'>https://rikoten.com</a>
+</body>
+</html>


### PR DESCRIPTION
おそらく今後各参加団体が、当日の企画ページのURLを公開し始めると思われる。（広報の都合上やむを得ない）
404にならないように念のためリダイレクトをトップページに向けて張る